### PR TITLE
Adds the "ctrl-\" alternative keyboard shortcut for toggling the tree-view on Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Some general keyboard shortcuts that I use frequently.
 | Grammar Selector | `ctrl-shift-l` | `ctrl-shift-l`  | `ctrl-shift-l` |  |
 | Markdown Preview | `ctrl-shift-m` | `ctrl-shift-m`  | `ctrl-shift-m` |  |
 | Key Binding Resolver | `cmd-.` | `ctrl-.`  | `ctrl-.` |  |
-| Toggle Tree View | `cmd-k cmd-b` | `ctrl-k ctrl-b` | `ctrl-k ctrl-b` |  |
+| Toggle Tree View | `cmd-k cmd-b` | `ctrl-k ctrl-b` | `ctrl-k ctrl-b`<br/>`ctrl-\`|  |
 | Reload Atom | `ctrl-alt-cmd-l` | `alt-ctrl-r` |  |  |
 | Open Link | `ctrl-shift-o` |  |  |  |
 | Toggle Developer Tools | `alt-cmd-i` | `ctrl-alt-i`  |  |  |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Some general keyboard shortcuts that I use frequently.
 | Grammar Selector | `ctrl-shift-l` | `ctrl-shift-l`  | `ctrl-shift-l` |  |
 | Markdown Preview | `ctrl-shift-m` | `ctrl-shift-m`  | `ctrl-shift-m` |  |
 | Key Binding Resolver | `cmd-.` | `ctrl-.`  | `ctrl-.` |  |
-| Toggle Tree View | `cmd-k cmd-b` | `ctrl-k ctrl-b` | `ctrl-k ctrl-b`<br/>`ctrl-\`|  |
+| Toggle Tree View | `cmd-k cmd-b` | `ctrl-k ctrl-b` | `ctrl-k ctrl-b`<br/>or<br/>`ctrl-\`|  |
 | Reload Atom | `ctrl-alt-cmd-l` | `alt-ctrl-r` |  |  |
 | Open Link | `ctrl-shift-o` |  |  |  |
 | Toggle Developer Tools | `alt-cmd-i` | `ctrl-alt-i`  |  |  |


### PR DESCRIPTION
Since I am only on Linux and can't easily test for the shortcut on other operating systems, I've only included the shortcut for Linux. 